### PR TITLE
[docs]: Update the documentation for the Tabs Component #11060

### DIFF
--- a/docs/docs/widgets/tabs.md
+++ b/docs/docs/widgets/tabs.md
@@ -105,7 +105,7 @@ Following actions of Tabs component can be controlled using the component specif
 
 <div style={{paddingTop:'24px'}}>
 
-## Devices
+## Devices 
 
 | <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
#11060
Formatting updates:

Replaced "Fx" and "FX" with "fx" 
For each h2 (created using ##), removed 24px padding-bottom. The div that wraps up the h2 headers and the section below the header should only have a "padding-top" of 24px and no "padding-bottom".

Content updates:
Replaced the word "widget" with "component" wherever applicable.  Updated the title name from "Layout" to "Devices"
Updated the name of the first column from "Layout" to "Property" Update the content in the "Description" and "Expected value" columns as per the given reference Added a full stop at the end of the sentence in the "Description" column. Added a divider before the "Styles" section reference The changes are to be implemented in both the file


Before:
![before](https://github.com/user-attachments/assets/afcc4c85-0780-414f-a196-86f75fafdb49)

After:
![after](https://github.com/user-attachments/assets/639aaadc-8e22-4a20-847e-5050b581a8e8)
